### PR TITLE
Fix controller base class

### DIFF
--- a/Cars-E/app/Http/Controllers/Controller.php
+++ b/Cars-E/app/Http/Controllers/Controller.php
@@ -2,7 +2,12 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 }

--- a/Cars-E/tests/CreatesApplication.php
+++ b/Cars-E/tests/CreatesApplication.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Contracts\Console\Kernel;
+
+trait CreatesApplication
+{
+    public function createApplication()
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Kernel::class)->bootstrap();
+
+        return $app;
+    }
+}
+

--- a/Cars-E/tests/TestCase.php
+++ b/Cars-E/tests/TestCase.php
@@ -6,5 +6,5 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    use CreatesApplication;
 }


### PR DESCRIPTION
## Summary
- extend the project controller from Laravel's base controller
- update tests skeleton to bootstrap the application properly

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68839dc8361c832a8cf4bbb42aed05bd